### PR TITLE
Change supported version to MPS 2021.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    mps("com.jetbrains:mps:2021.1.+")
-    generation("com.mbeddr:platform:2021.1.+")
-    generation("com.mbeddr:mbeddr:2021.1.+")
+    mps("com.jetbrains:mps:2021.2.+")
+    generation("com.mbeddr:platform:2021.2.+")
+    generation("com.mbeddr:mbeddr:2021.2.+")
 }

--- a/solutions/mps-richtext-glossaries.build/models/mps-richtext-glossaries.build.mps
+++ b/solutions/mps-richtext-glossaries.build/models/mps-richtext-glossaries.build.mps
@@ -153,7 +153,7 @@
       <node concept="aVJcg" id="76RcO2KNzx9" role="aVJcv">
         <node concept="NbPM2" id="76RcO2KNzx8" role="aVJcq">
           <node concept="3Mxwew" id="76RcO2KNzx7" role="3MwsjC">
-            <property role="3MwjfP" value="2021.1.1" />
+            <property role="3MwjfP" value="2021.1.2" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
To support MPS 2021.2 reliably, dependencies needed to be updated to versions that run in MPS 2021.2